### PR TITLE
Remove unused imports from Vue components

### DIFF
--- a/ui/src/components/document/ConfigSidebar.vue
+++ b/ui/src/components/document/ConfigSidebar.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { type Document } from '../../api/document';
-import { Transition } from 'vue';
 
 const props = defineProps<{
   visible: boolean;

--- a/ui/src/views/Document.vue
+++ b/ui/src/views/Document.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, watch, ref, onUnmounted, nextTick, type Directive } from 'vue';
+import { computed, onMounted, watch, ref, onUnmounted, nextTick } from 'vue';
 import { useRoute } from 'vue-router';
 import { useDocumentStore } from '../stores/document';
 import { useFavoriteStore } from '../stores/favorite';


### PR DESCRIPTION
Eliminate unnecessary imports of `Directive` and `Transition` from `Document.vue` and `ConfigSidebar.vue`, respectively.