### PR TITLE
Add cache-dependency-path for npm in workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,6 +31,7 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
+        cache-dependency-path: ui/package-lock.json
 
     # get date for versioning
     - name: Get date

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
+        cache-dependency-path: ui/package-lock.json
 
     - uses: nowsprinting/check-version-format-action@v3
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
Include `cache-dependency-path` in the npm workflow to optimize caching based on the `package-lock.json` file.